### PR TITLE
allow running of Bot::Cobalt from 'git clone'd directory

### DIFF
--- a/lib/Bot/Cobalt/Lang.pm
+++ b/lib/Bot/Cobalt/Lang.pm
@@ -79,7 +79,15 @@ has _core_set => (
   coerce    => 1,
   builder   => sub {
     my ($self) = @_;
-    my $cset_path = dist_dir('Bot-Cobalt') .'/etc/langs/english.yml';
+    my $english_yml = '/etc/langs/english.yml';
+    my $cset_path   = eval { dist_dir('Bot-Cobalt') . $english_yml };
+
+    if ( ! $cset_path ) { # running Bot::Cobalt from 'git clone' dir or similar
+      my $bot_cobalt_pm = $INC{'Bot/Cobalt.pm'};
+      (my $base_dir     = $bot_cobalt_pm) =~ s|\Q/lib/Bot/Cobalt.pm\E$||;
+      $cset_path        = $base_dir . '/share' . $english_yml;
+    }
+
     my $core_set_yaml = path($cset_path)->slurp_utf8;
     confess "Failed to read core set at $cset_path"
       unless $core_set_yaml;


### PR DESCRIPTION
Bot::Cobalt will only run when it has been 'make install'ed or equivalent
because of the File::ShareDir::dist_dir('Bot-Cobalt') call.

This change allows running Bot::Cobalt from the source directory by looking in
itself for the core language file if trying to find it via dist_dir fails.

This pull request was done as my assignment for the January 2017 CPAN pull request challenge:

http://cpan-prc.org/2017/january.html